### PR TITLE
Enable building for development on non-Windows platforms

### DIFF
--- a/SporeMods.NetCoreSharedAssemblyInfo.props
+++ b/SporeMods.NetCoreSharedAssemblyInfo.props
@@ -6,4 +6,10 @@
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>
 	<TargetLatestRuntimePatch>False</TargetLatestRuntimePatch>
   </PropertyGroup>
+  
+  <ItemGroup>
+	<KnownFrameworkReference Update="Microsoft.WindowsDesktop.App" IsWindowsOnly="false" />
+	<KnownFrameworkReference Update="Microsoft.WindowsDesktop.App.WPF" IsWindowsOnly="false" />
+	<KnownFrameworkReference Update="Microsoft.WindowsDesktop.App.WindowsForms" IsWindowsOnly="false" />
+  </ItemGroup>
 </Project>

--- a/SporeMods.SharedOutputDirs.props
+++ b/SporeMods.SharedOutputDirs.props
@@ -3,6 +3,11 @@
   <PropertyGroup>
     <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
 	<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OutputPath>..\devBin\$(Configuration)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT' and Exists('BUILD_TO_USER_DIR')">
     <OutputPath>$(userprofile)\Spore Mod Manager\bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">


### PR DESCRIPTION
Note to self: Look into publishing on non-Windows platforms at some point.

For now, this is progress.