### PR TITLE
Add support for Mod Identity 1.0.1.2

### DIFF
--- a/SporeMods.Core/ModInstallation.cs
+++ b/SporeMods.Core/ModInstallation.cs
@@ -374,6 +374,11 @@ namespace SporeMods.Core
 									{
 										if (dllsBuild > Settings.CurrentDllsBuild)
 											throw new UnsupportedDllsBuildException(dllsBuild);
+										if (identityVersion < ModIdentity.XmlModIdentityVersion1_0_1_2)
+                                        {
+											if (dllsBuild > ModIdentity.MAX_DLLS_BUILD_PRE_MI1_0_1_2)
+												throw new UnsupportedDllsBuildException(dllsBuild);
+										}
 									}
 									else
 										throw new UnsupportedDllsBuildException(ModIdentity.UNKNOWN_MOD_VERSION);

--- a/SporeMods.Core/ModInstallation.cs
+++ b/SporeMods.Core/ModInstallation.cs
@@ -401,8 +401,14 @@ namespace SporeMods.Core
 									&& (dllsBuild > ModIdentity.MAX_DLLS_BUILD_PRE_MI1_0_1_2)
 								)
 							{
-								if (!ModIdentity.PRE_MI1_0_1_2_EXCLUDE_FROM_DLLS_BUILD_CUTOFF_UNIQUES.Any(x => x == unique))
+								if
+								(!(
+									   (dllsBuild == ModIdentity.PRE_MI1_0_1_2_EXCLUDE_FROM_DLLS_BUILD_CUTOFF_LOCKED_DLLS_BUILD)
+									&& ModIdentity.PRE_MI1_0_1_2_EXCLUDE_FROM_DLLS_BUILD_CUTOFF_UNIQUES.Any(x => x == unique)
+								))
+								{
 									throw new UnsupportedDllsBuildException(dllsBuild);
+								}
 							}
 
 							var vanillaCompatAttr = compareDocument.Root.Attribute("verifiedVanillaCompatible");

--- a/SporeMods.Core/ModInstallation.cs
+++ b/SporeMods.Core/ModInstallation.cs
@@ -365,20 +365,16 @@ namespace SporeMods.Core
 							else
 								throw new MissingXmlModIdentityAttributeException(null);
 
-							if (identityVersion > ModIdentity.XmlModIdentityVersion1_0_0_0)
+							Version dllsBuild = null;
+							if(identityVersion > ModIdentity.XmlModIdentityVersion1_0_0_0)
 							{
 								var dllsBuildAttr = compareDocument.Root.Attribute("dllsBuild");
 								if (dllsBuildAttr != null)
 								{
-									if (Version.TryParse(dllsBuildAttr.Value + ".0", out Version dllsBuild))
+									if (Version.TryParse(dllsBuildAttr.Value + ".0", out dllsBuild))
 									{
 										if (dllsBuild > Settings.CurrentDllsBuild)
 											throw new UnsupportedDllsBuildException(dllsBuild);
-										if (identityVersion < ModIdentity.XmlModIdentityVersion1_0_1_2)
-                                        {
-											if (dllsBuild > ModIdentity.MAX_DLLS_BUILD_PRE_MI1_0_1_2)
-												throw new UnsupportedDllsBuildException(dllsBuild);
-										}
 									}
 									else
 										throw new UnsupportedDllsBuildException(ModIdentity.UNKNOWN_MOD_VERSION);
@@ -397,6 +393,16 @@ namespace SporeMods.Core
 
 								dir = Path.Combine(Settings.ModConfigsPath, unique);
 								name = unique;
+							}
+
+							if (
+									   (identityVersion < ModIdentity.XmlModIdentityVersion1_0_1_2)
+									&& (dllsBuild != null)
+									&& (dllsBuild > ModIdentity.MAX_DLLS_BUILD_PRE_MI1_0_1_2)
+								)
+							{
+								if (!ModIdentity.MI1_0_1_1_EXCLUDE_FROM_DLLS_BUILD_CUTOFF_UNIQUES.Any(x => x == unique))
+									throw new UnsupportedDllsBuildException(dllsBuild);
 							}
 
 							var vanillaCompatAttr = compareDocument.Root.Attribute("verifiedVanillaCompatible");

--- a/SporeMods.Core/ModInstallation.cs
+++ b/SporeMods.Core/ModInstallation.cs
@@ -366,7 +366,7 @@ namespace SporeMods.Core
 								throw new MissingXmlModIdentityAttributeException(null);
 
 							Version dllsBuild = null;
-							if(identityVersion > ModIdentity.XmlModIdentityVersion1_0_0_0)
+							if (identityVersion > ModIdentity.XmlModIdentityVersion1_0_0_0)
 							{
 								var dllsBuildAttr = compareDocument.Root.Attribute("dllsBuild");
 								if (dllsBuildAttr != null)
@@ -395,7 +395,7 @@ namespace SporeMods.Core
 								name = unique;
 							}
 
-							if (
+							/*if (
 									   (identityVersion < ModIdentity.XmlModIdentityVersion1_0_1_2)
 									&& (dllsBuild != null)
 									&& (dllsBuild > ModIdentity.MAX_DLLS_BUILD_PRE_MI1_0_1_2)
@@ -409,6 +409,10 @@ namespace SporeMods.Core
 								{
 									throw new UnsupportedDllsBuildException(dllsBuild);
 								}
+							}*/
+							if (!HasValidDllsVersion__MI1_0_1_2__Hack(identityVersion, dllsBuild, unique))
+                            {
+								throw new UnsupportedDllsBuildException(dllsBuild);
 							}
 
 							var vanillaCompatAttr = compareDocument.Root.Attribute("verifiedVanillaCompatible");
@@ -779,6 +783,36 @@ namespace SporeMods.Core
 			bool blankName = string.IsNullOrEmpty(eName);
 
 			return (backSlash || foreSlash) && blankName;
+		}
+
+
+		static bool HasValidDllsVersion__MI1_0_1_2__Hack(Version identityVersion, Version dllsBuild, string unique)
+		{
+			Version installerSystemVersion = identityVersion;
+			Version requiredDllsVersion = dllsBuild;
+			Version OldLauncherDllsBuild = ModIdentity.MAX_DLLS_BUILD_PRE_MI1_0_1_2;
+
+			if (requiredDllsVersion > OldLauncherDllsBuild)
+			{
+				// Only allow these mods unless they have the newer installer version, to ensure they don't get released into old Launcher versions
+				if (installerSystemVersion < ModIdentity.XmlModIdentityVersion1_0_1_2)
+				{
+					// Some mods already existed with newer DLL version but same installerSystemVersion
+					// We make exceptions for them here
+					if (!((ModIdentity.PRE_MI1_0_1_2_EXCLUDE_FROM_DLLS_BUILD_CUTOFF_UNIQUES.Contains(unique)) &&
+						  requiredDllsVersion.Major == 2 && requiredDllsVersion.Minor == 5 && requiredDllsVersion.Build == 179))
+						return false;
+				}
+			}
+
+			/*if (requiredDllsVersion != null &&
+				requiredDllsVersion > CurrentDllsBuild)
+			{
+				return false;
+			}*/
+
+
+			return true;
 		}
 	}
 

--- a/SporeMods.Core/ModInstallation.cs
+++ b/SporeMods.Core/ModInstallation.cs
@@ -401,7 +401,7 @@ namespace SporeMods.Core
 									&& (dllsBuild > ModIdentity.MAX_DLLS_BUILD_PRE_MI1_0_1_2)
 								)
 							{
-								if (!ModIdentity.MI1_0_1_1_EXCLUDE_FROM_DLLS_BUILD_CUTOFF_UNIQUES.Any(x => x == unique))
+								if (!ModIdentity.PRE_MI1_0_1_2_EXCLUDE_FROM_DLLS_BUILD_CUTOFF_UNIQUES.Any(x => x == unique))
 									throw new UnsupportedDllsBuildException(dllsBuild);
 							}
 

--- a/SporeMods.Core/Mods/ModIdentity.cs
+++ b/SporeMods.Core/Mods/ModIdentity.cs
@@ -21,6 +21,11 @@ namespace SporeMods.Core.Mods
 		public static readonly Version UNKNOWN_MOD_VERSION = new Version(0, 0, 0, 0);
 
 		public static readonly Version MAX_DLLS_BUILD_PRE_MI1_0_1_2 = new Version(2, 5, 20, 0);
+		public static readonly string[]
+			MI1_0_1_1_EXCLUDE_FROM_DLLS_BUILD_CUTOFF_UNIQUES =
+		{
+			//TODO: Add unique identifiers for mods to exclude here
+		};
 
 		public static bool IsLauncherKitCompatibleXmlModIdentityVersion(Version identityVersion)
 		{

--- a/SporeMods.Core/Mods/ModIdentity.cs
+++ b/SporeMods.Core/Mods/ModIdentity.cs
@@ -22,7 +22,7 @@ namespace SporeMods.Core.Mods
 
 		public static readonly Version MAX_DLLS_BUILD_PRE_MI1_0_1_2 = new Version(2, 5, 20, 0);
 		public static readonly string[]
-			MI1_0_1_1_EXCLUDE_FROM_DLLS_BUILD_CUTOFF_UNIQUES =
+			PRE_MI1_0_1_2_EXCLUDE_FROM_DLLS_BUILD_CUTOFF_UNIQUES =
 		{
 			//TODO: Add unique identifiers for mods to exclude here
 		};

--- a/SporeMods.Core/Mods/ModIdentity.cs
+++ b/SporeMods.Core/Mods/ModIdentity.cs
@@ -16,14 +16,18 @@ namespace SporeMods.Core.Mods
 		public static readonly Version XmlModIdentityVersion1_0_0_0 = new Version(1, 0, 0, 0);
 		public static readonly Version XmlModIdentityVersion1_0_1_0 = new Version(1, 0, 1, 0);
 		public static readonly Version XmlModIdentityVersion1_0_1_1 = new Version(1, 0, 1, 1);
+		public static readonly Version XmlModIdentityVersion1_0_1_2 = new Version(1, 0, 1, 2);
 		public static readonly Version XmlModIdentityVersion1_1_0_0 = new Version(1, 1, 0, 0);
 		public static readonly Version UNKNOWN_MOD_VERSION = new Version(0, 0, 0, 0);
+
+		public static readonly Version MAX_DLLS_BUILD_PRE_MI1_0_1_2 = new Version(2, 5, 20, 0);
 
 		public static bool IsLauncherKitCompatibleXmlModIdentityVersion(Version identityVersion)
 		{
 			return (identityVersion == ModIdentity.XmlModIdentityVersion1_0_0_0) ||
 					(identityVersion == ModIdentity.XmlModIdentityVersion1_0_1_0) ||
-					(identityVersion == ModIdentity.XmlModIdentityVersion1_0_1_1);
+					(identityVersion == ModIdentity.XmlModIdentityVersion1_0_1_1) ||
+					(identityVersion == ModIdentity.XmlModIdentityVersion1_0_1_2);
 		}
 
 		/*public static bool IsValidUnique(string inputUnique)

--- a/SporeMods.Core/Mods/ModIdentity.cs
+++ b/SporeMods.Core/Mods/ModIdentity.cs
@@ -21,10 +21,12 @@ namespace SporeMods.Core.Mods
 		public static readonly Version UNKNOWN_MOD_VERSION = new Version(0, 0, 0, 0);
 
 		public static readonly Version MAX_DLLS_BUILD_PRE_MI1_0_1_2 = new Version(2, 5, 20, 0);
-		public static readonly string[]
-			PRE_MI1_0_1_2_EXCLUDE_FROM_DLLS_BUILD_CUTOFF_UNIQUES =
+		public static readonly Version PRE_MI1_0_1_2_EXCLUDE_FROM_DLLS_BUILD_CUTOFF_LOCKED_DLLS_BUILD = new Version(2, 5, 179, 0);
+
+		public static readonly string[] PRE_MI1_0_1_2_EXCLUDE_FROM_DLLS_BUILD_CUTOFF_UNIQUES =
 		{
-			//TODO: Add unique identifiers for mods to exclude here
+			"AssetSharing",
+			"CaptainVoiceDiversity"
 		};
 
 		public static bool IsLauncherKitCompatibleXmlModIdentityVersion(Version identityVersion)


### PR DESCRIPTION
Adds support for Mod Identity 1.0.1.2, thereby bringing the SMM back up to its previous level of feature-parity with the Launcher Kit.